### PR TITLE
Improve dashboard UI

### DIFF
--- a/src/app/animations.ts
+++ b/src/app/animations.ts
@@ -1,0 +1,17 @@
+import { trigger, style, animate, transition } from '@angular/animations';
+
+export const appear = [
+  trigger('appear', [
+    transition(':enter', [
+      style({
+        transform: 'translateY(-3%)',
+        opacity: 0,
+        position: 'static'
+      }),
+      animate(
+        '0.5s ease-in-out',
+        style({ transform: 'translateY(0%)', opacity: 1 })
+      )
+    ])
+  ]),
+];

--- a/src/app/articles/article/article.component.html
+++ b/src/app/articles/article/article.component.html
@@ -1,3 +1,3 @@
-<div class="mat-title push-bottom-none">{{title}}</div>
-<div class="mat-subheading-2">{{author}}</div>
+<div *ngIf="title" class="mat-title push-bottom-none">{{title}}</div>
+<div *ngIf="author" class="mat-subheading-2">{{author}}</div>
 <td-markdown [content]="content"></td-markdown>

--- a/src/app/articles/articles.component.html
+++ b/src/app/articles/articles.component.html
@@ -1,8 +1,9 @@
 <mat-list>
   <ng-template let-article let-last="last" ngFor [ngForOf]="articles$ | async">
-    <mat-list-item layout-align="row" (click)="navigateToArticle(article)">
+    <mat-list-item @appear layout-align="row" (click)="navigateToArticle(article)">
       <h3 matLine>{{article.title}}</h3>
-      <p matLine>{{article.author}}</p>
+      <p matLine class="accent">{{article.author}}</p>
+      <p matLine>{{article.content}}</p>
     </mat-list-item>
     <mat-divider *ngIf="!last" [inset]="true"></mat-divider>
   </ng-template>

--- a/src/app/articles/articles.component.scss
+++ b/src/app/articles/articles.component.scss
@@ -1,3 +1,9 @@
+@import '../../constants.scss';
+
 mat-list-item {
   cursor: pointer;
+}
+
+p.accent {
+  color: mat-color($accent);
 }

--- a/src/app/articles/articles.component.ts
+++ b/src/app/articles/articles.component.ts
@@ -3,12 +3,14 @@ import { Router } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 import { map } from 'rxjs/operators/map';
 
+import { appear } from '../animations';
 import { ArticlesService } from './articles.service';
 
 @Component({
   selector: 'app-articles',
   templateUrl: './articles.component.html',
-  styleUrls: ['./articles.component.scss']
+  styleUrls: ['./articles.component.scss'],
+  animations: appear
 })
 export class ArticlesComponent implements OnInit {
   @Input() maxArticles?: number;

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -18,7 +18,7 @@
               <span class="mat-title pad-right-xs">{{stock.value | number:'.2'}}</span>
               <span [ngClass]="{'tc-red-500': !stock.isUp, 'tc-green-500': stock.isUp}" class="mat-subheading-2">{{stock.isUp ? '+' : '-'}}{{stock.valueChange}} ({{stock.percentChange}}%)</span>
             </mat-card-subtitle>
-            <img mat-card-md-image [src]=stock.image>
+            <img class="pad" mat-card-md-image [src]=stock.image>
           </mat-card-title-group>
         </mat-card>
       </div>
@@ -45,6 +45,7 @@
           <app-articles
             [maxArticles]="maxArticles">
           </app-articles>
+          <mat-divider></mat-divider>
           <mat-card-actions>
             <button routerLink="/news" mat-button class="text-upper">View more</button>
           </mat-card-actions>

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -7,21 +7,25 @@
     <span flex></span>
     <app-notifications></app-notifications>
   </div>
-  <div>
-    <div layout-gt-xs="row">
-      <div flex-gt-xs="33" *ngFor="let stock of stocks">
-        <mat-card>
-          <mat-card-content class="text-center">
-            <app-stock-summary
-              [stock]="stock">
-            </app-stock-summary>
-          </mat-card-content>
+  <ng-template tdLoading="loadingOverlay" tdLoadingMode="indeterminate" tdLoadingType="circle" tdLoadingStrategy="replace" tdLoadingColor="accent">
+  <div *ngIf="stocks">
+    <div layout-gt-xs="row" class="flex-wrap-center">
+      <div flex-gt-sm="33" *ngFor="let stock of stocks">
+        <mat-card @appear>
+          <mat-card-title-group>
+            <mat-card-title class="text-xxl">{{stock.symbol}}</mat-card-title>
+            <mat-card-subtitle>
+              <span class="mat-title pad-right-xs">{{stock.value | number:'.2'}}</span>
+              <span [ngClass]="{'tc-red-500': !stock.isUp, 'tc-green-500': stock.isUp}" class="mat-subheading-2">{{stock.isUp ? '+' : '-'}}{{stock.valueChange}} ({{stock.percentChange}}%)</span>
+            </mat-card-subtitle>
+            <img mat-card-md-image [src]=stock.image>
+          </mat-card-title-group>
         </mat-card>
       </div>
     </div>
     <div layout-gt-xs="row">
-      <div flex-gt-sm="60" class="chart">
-        <mat-card>
+      <div flex-gt-xs="60" class="chart">
+        <mat-card @appear>
           <mat-card-title>Stocks</mat-card-title>
           <mat-card-content>
             <div class="chart">
@@ -34,15 +38,19 @@
           </mat-card-content>
         </mat-card>
       </div>
-      <div flex-gt-sm="40">
-        <mat-card>
+      <div flex-gt-xs="40">
+        <mat-card @appear>
           <mat-card-title>Recent News</mat-card-title>
           <mat-divider></mat-divider>
           <app-articles
             [maxArticles]="maxArticles">
           </app-articles>
+          <mat-card-actions>
+            <button routerLink="/news" mat-button class="text-upper">View more</button>
+          </mat-card-actions>
         </mat-card>
       </div>
     </div>
   </div>
+</ng-template>
 </td-layout-nav>

--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -5,3 +5,8 @@
 .chart-height {
   height: 300px;
 }
+
+.flex-wrap-center {
+  flex-wrap: wrap;
+  justify-content: center;
+}

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
+import { TdLoadingService } from '@covalent/core/loading';
 
+import { appear } from '../animations';
 import { StocksService } from '../stocks/stocks.service';
 
 @Component({
   selector: 'app-dashboard',
   templateUrl: './dashboard.component.html',
-  styleUrls: ['./dashboard.component.scss']
+  styleUrls: ['./dashboard.component.scss'],
+  animations: appear
 })
 export class DashboardComponent implements OnInit {
   view;
@@ -13,11 +16,13 @@ export class DashboardComponent implements OnInit {
   maxArticles = 3;
   stockData: any;
 
-  constructor(private _stocksService: StocksService) { }
+  constructor(private _stocksService: StocksService, private _tdLoadingService: TdLoadingService) { }
 
   ngOnInit() {
+    this._tdLoadingService.register('loadingOverlay');
     this._stocksService.getStocks()
       .subscribe(stockData => {
+        this._tdLoadingService.resolve('loadingOverlay');
         this.stocks = stockData.stocks;
         this.stockData = stockData.stockGraphData
       });

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CovalentLayoutModule } from '@covalent/core/layout';
+import { CovalentLoadingModule } from '@covalent/core/loading';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCardModule } from '@angular/material/card';
 import { MatDividerModule } from '@angular/material/divider';
@@ -17,6 +18,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
   imports: [
     CommonModule,
     CovalentLayoutModule,
+    CovalentLoadingModule,
     MatIconModule,
     MatCardModule,
     MatDividerModule,

--- a/src/app/news-creator/news-creator.component.html
+++ b/src/app/news-creator/news-creator.component.html
@@ -5,44 +5,64 @@
   <div td-toolbar-content>
     <span>News Creator</span>
   </div>
-  <td-steps [mode]="stepsMode" *ngIf="!submitted">
-    <td-step #metaDataStep label="Enter title and author" [active]="activeStep === 'metaData'" (activated)="toStep('metaData')" [state]="getStateFromForm(metaDataForm)">
-      <td-dynamic-forms #metaDataForm [elements]="metaDataElements">
-        <ng-template let-element ngFor [ngForOf]="metaDataElements">
-          <ng-template let-control="control" [tdDynamicFormsError]="element.name">
-          </ng-template>
-        </ng-template>
-      </td-dynamic-forms>
-      <ng-template td-step-actions>
-        <button mat-raised-button color="primary" class="text-upper" (click)="toStep('content')" [disabled]="!metaDataForm.valid">Next</button>
-      </ng-template>
-    </td-step>
-    <td-step label="Enter content" [active]="activeStep === 'content'" (activated)="toStep('content')" [disabled]="!metaDataForm.valid" [state]="getStateFromEditor(textEditor)">
-      <td-text-editor [options]="contentOptions" #textEditor></td-text-editor>
-      <ng-template td-step-actions>
-        <button mat-button class="text-upper" (click)="toStep('metaData')">Previous</button>
-        <button mat-raised-button color="primary" class="text-upper" (click)="toStep('preview')" [disabled]="!textEditor.simpleMDE || !textEditor.simpleMDE.value()">Next</button>
-      </ng-template>
-    </td-step>
-    <td-step label="Preview and Finish" [active]="activeStep === 'preview'" (activated)="toStep('preview')" [disabled]="!textEditor.simpleMDE || !textEditor.simpleMDE.value()">
-      <div class="centered-readable-content">
-        <app-article
-          *ngIf="activeStep === 'preview'"
-          [title]="metaDataForm.value.Title"
-          [author]="metaDataForm.value.Author"
-          [content]="textEditor.simpleMDE.value()">
-        </app-article>
-      </div>
-      <ng-template td-step-summary>
-        Use an optional step summary to summarize the info in this step
-      </ng-template>
-      <ng-template td-step-actions>
-        <button mat-button class="text-upper" (click)="toStep('content')">Previous</button>
-        <button mat-raised-button color="primary" class="text-upper" (click)="submitArticle()">Finish</button>
-      </ng-template>
-    </td-step>
-  </td-steps>
-  <div *ngIf="submitted" class="mat-headline centered-readable-content">
-    Thank you for submitting your article.
-  </div>
+  <td-layout-card-over @appear [cardTitle]="cardOverTitle" [cardSubtitle]="cardOverSubtitle">
+    <ng-template tdLoading="loadingOverlay" tdLoadingMode="indeterminate" tdLoadingType="circle" tdLoadingStrategy="overlay" tdLoadingColor="accent">
+      <mat-card-content *ngIf="!submitted">
+        <td-steps mode="vertical" *ngIf="!submitted">
+          <td-step #metaDataStep label="Enter title and author" [active]="activeStep === 'metaData'" (activated)="toStep('metaData')" [state]="formState" (deactivated)="formState = getStateFromForm(metaDataForm)">
+            <td-dynamic-forms #metaDataForm [elements]="metaDataElements">
+              <ng-template let-element ngFor [ngForOf]="metaDataElements">
+                <ng-template let-control="control" [tdDynamicFormsError]="element.name">
+                </ng-template>
+              </ng-template>
+            </td-dynamic-forms>
+            <ng-template td-step-actions>
+              <button mat-button color="primary" class="text-upper" (click)="toStep('content'); formState = 'complete'" [disabled]="!metaDataForm.valid">Continue</button>
+              <button mat-button class="text-upper" (click)="clearForm()">Cancel</button>
+            </ng-template>
+            <ng-template td-step-summary>
+              <div>Title: {{metaDataForm.value.Title}}</div>
+              <div>Author: {{metaDataForm.value.Author}}</div>
+            </ng-template>
+          </td-step>
+          <td-step label="Enter content" [active]="activeStep === 'content'" (activated)="toStep('content')" [disabled]="!metaDataForm.valid" [state]="contentState" (deactivated)="contentState = getStateFromEditor(textEditor)">
+            <td-text-editor [options]="contentOptions" #textEditor></td-text-editor>
+            <ng-template td-step-actions>
+              <button mat-button color="primary" class="text-upper" (click)="toStep('preview'); contentState = 'complete'" [disabled]="!textEditor.simpleMDE || !textEditor.simpleMDE.value()">Continue</button>
+              <button mat-button class="text-upper" (click)="clearEditor()">Cancel</button>
+            </ng-template>
+            <ng-template td-step-summary>
+              <app-article
+                *ngIf="!!textEditor && !!textEditor.simpleMDE && !!textEditor.simpleMDE.value()"
+                [content]="textEditor.simpleMDE.value()">
+              </app-article>
+            </ng-template>
+          </td-step>
+          <td-step label="Preview and Finish" [active]="activeStep === 'preview'" (activated)="toStep('preview')" [disabled]="!textEditor.simpleMDE || !textEditor.simpleMDE.value()">
+            <div class="centered-readable-content">
+              <app-article
+                *ngIf="activeStep === 'preview'"
+                [title]="metaDataForm.value.Title"
+                [author]="metaDataForm.value.Author"
+                [content]="textEditor.simpleMDE.value()">
+              </app-article>
+            </div>
+            <ng-template td-step-summary>
+              Use an optional step summary to summarize the info in this step
+            </ng-template>
+            <!-- <ng-template td-step-actions>
+              <button mat-button class="text-upper" (click)="toStep('content')">Previous</button>
+              <button mat-button color="primary" class="text-upper" (click)="submitArticle()">Finish</button>
+            </ng-template> -->
+          </td-step>
+        </td-steps>
+        <mat-divider matDivider></mat-divider>
+        <button mat-raised-button color="primary" class="text-upper push-top" (click)="submitArticle()">Save</button>
+        <button mat-button class="text-upper" (click)="clearAll()">Cancel</button>
+      </mat-card-content>
+    </ng-template>
+    <mat-card-content *ngIf="submitted">
+      Your article is currently being reviewed and processed. You should see your article appear within 24 hours. Thank you for your submission.
+    </mat-card-content>
+  </td-layout-card-over>
 </td-layout-nav>

--- a/src/app/news-creator/news-creator.component.scss
+++ b/src/app/news-creator/news-creator.component.scss
@@ -1,4 +1,9 @@
 .centered-readable-content {
   max-width: 33em;
   margin: 0 auto;
+
+  // &.mat-headline{
+  //   text-align: center;
+  //   min-height: 210px;
+  // }
 }

--- a/src/app/news-creator/news-creator.component.ts
+++ b/src/app/news-creator/news-creator.component.ts
@@ -1,13 +1,19 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectorRef, ViewChild } from '@angular/core';
 
-import { TdMediaService } from '@covalent/core/media';
+import { TdDialogService } from '@covalent/core/dialogs';
+import { TdLoadingService } from '@covalent/core/loading';
+
+import { appear } from '../animations';
 
 @Component({
   selector: 'app-news-creator',
   templateUrl: './news-creator.component.html',
-  styleUrls: ['./news-creator.component.scss']
+  styleUrls: ['./news-creator.component.scss'],
+  animations: appear
 })
-export class NewsCreatorComponent implements OnInit, OnDestroy {
+export class NewsCreatorComponent {
+  @ViewChild('metaDataForm') _metaDataForm;
+  @ViewChild('textEditor') _textEditor;
   activeStep: 'metaData' | 'content' | 'preview' = 'metaData';
   metaDataElements = [{
     name: 'Title',
@@ -24,29 +30,23 @@ export class NewsCreatorComponent implements OnInit, OnDestroy {
     autosave: true
   };
   submitted = false;
+  cardOverTitle = 'News Story Creator';
+  cardOverSubtitle = 'Create a news story to add to the dashboard.';
   stepsMode = 'horizontal';
+  formState = 'none';
+  contentState = 'none';
 
-  private didInitiateComponent = false;
-  private mediaServiceSubscription;
-
-  constructor(private tdMediaService: TdMediaService) { }
-
-  ngOnInit() {
-    this.mediaServiceSubscription = this.tdMediaService.registerQuery('gt-sm')
-      .subscribe(isGreaterThanSmall => {
-        this.stepsMode = isGreaterThanSmall ? 'horizontal' : 'vertical';
-      });
-  }
+  constructor(
+    private _tdDialogService: TdDialogService,
+    private _tdLoadingService: TdLoadingService,
+    private _changeDetectorRef: ChangeDetectorRef
+  ) { }
 
   toStep(step: 'metaData' | 'content' | 'preview') {
     this.activeStep = step;
   }
 
   getStateFromForm(form) {
-    if (!this.didInitiateComponent) {
-      this.didInitiateComponent = true;
-      return 'required';
-    }
     return !form.valid ? 'required' : 'complete';
   }
 
@@ -54,11 +54,44 @@ export class NewsCreatorComponent implements OnInit, OnDestroy {
     return editor && editor.simpleMDE && editor.simpleMDE.value() ? 'complete' : 'required';
   }
 
-  submitArticle() {
-    this.submitted = true;
+  clearEditor() {
+    this._textEditor.value = '';
+    this._changeDetectorRef.detectChanges();
   }
 
-  ngOnDestroy() {
-    this.mediaServiceSubscription.unsubscribe();
+  clearForm() {
+    this._metaDataForm.form.reset();
+  }
+
+  clearAll() {
+    this.clearForm();
+    this.clearEditor();
+    this.activeStep = 'metaData';
+  }
+
+  submitArticle() {
+    if (!this._metaDataForm || !this._metaDataForm.valid ||
+      !this._textEditor || !this._textEditor.simpleMDE || !this._textEditor.simpleMDE.value()) {
+      this._tdDialogService.openAlert({
+        message: 'Please complete form before submitting.'
+      });
+      return;
+    }
+    this._tdDialogService.openConfirm({
+      title: 'Confirm submission',
+      message: 'You may not edit your article after submission. Are you sure you want to submit?',
+      cancelButton: 'No',
+      acceptButton: 'Yes'
+    }).afterClosed().subscribe((accept: boolean) => {
+      if (accept) {
+        this._tdLoadingService.register('loadingOverlay');
+        setTimeout(() => {
+          this._tdLoadingService.resolve('loadingOverlay');
+    this.submitted = true;
+          this.cardOverTitle = "Thank you for submitting your article";
+          this.cardOverSubtitle = '';
+        }, 2000);
+      }
+    });
   }
 }

--- a/src/app/news-creator/news-creator.module.ts
+++ b/src/app/news-creator/news-creator.module.ts
@@ -1,13 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { CovalentDialogsModule } from '@covalent/core/dialogs';
 import { CovalentDynamicFormsModule } from '@covalent/dynamic-forms';
 import { CovalentLayoutModule } from '@covalent/core/layout';
+import { CovalentLoadingModule } from '@covalent/core/loading';
 import { CovalentMediaModule } from '@covalent/core/media';
 import { CovalentStepsModule } from '@covalent/core/steps'
 import { CovalentTextEditorModule } from '@covalent/text-editor';
 import { PortalModule } from '@angular/cdk/portal'
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
+import { MatStepperModule } from '@angular/material/stepper';
 
 import { NewsCreatorRoutingModule } from './news-creator-routing.module';
 import { NewsCreatorComponent } from './news-creator.component';
@@ -16,14 +21,19 @@ import { ArticlesModule } from '../articles/articles.module';
 @NgModule({
   imports: [
     CommonModule,
+    CovalentDialogsModule,
     CovalentDynamicFormsModule,
     CovalentLayoutModule,
+    CovalentLoadingModule,
     CovalentMediaModule,
     CovalentStepsModule,
     CovalentTextEditorModule,
     PortalModule,
     MatButtonModule,
+    MatCardModule,
+    MatDividerModule,
     MatIconModule,
+    MatStepperModule,
     ArticlesModule,
     NewsCreatorRoutingModule
   ],

--- a/src/app/news/news-article/news-article.component.html
+++ b/src/app/news/news-article/news-article.component.html
@@ -5,9 +5,11 @@
   <div td-toolbar-content>
     <span>News</span>
   </div>
-  <app-article
-    [title]="article.title"
-    [author]="article.author"
-    [content]="article.content">
-  </app-article>
+  <td-layout-card-over @appear [cardTitle]="article.title" [cardSubtitle]="article.author">
+    <mat-card-content>
+      <app-article
+        [content]="article.content">
+      </app-article>
+    </mat-card-content>
+  </td-layout-card-over>
 </td-layout-nav>

--- a/src/app/news/news-article/news-article.component.scss
+++ b/src/app/news/news-article/news-article.component.scss
@@ -1,4 +1,4 @@
-app-article {
-  max-width: 33em;
-  margin: 0 auto;
-}
+// app-article {
+//   max-width: 33em;
+//   margin: 0 auto;
+// }

--- a/src/app/news/news-article/news-article.component.ts
+++ b/src/app/news/news-article/news-article.component.ts
@@ -1,10 +1,13 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+
+import { appear } from '../../animations';
 
 @Component({
   selector: 'app-news-article',
   templateUrl: './news-article.component.html',
-  styleUrls: ['./news-article.component.scss']
+  styleUrls: ['./news-article.component.scss'],
+  animations: appear
 })
 export class NewsArticleComponent implements OnInit {
   article;

--- a/src/app/news/news.component.html
+++ b/src/app/news/news.component.html
@@ -5,5 +5,11 @@
   <div td-toolbar-content>
     <span>News</span>
   </div>
-  <app-articles></app-articles>
+  <td-layout-card-over @appear cardTitle="News">
+    <mat-card-content>
+      <app-articles></app-articles>
+      <mat-divider matDivider></mat-divider>
+      <button mat-button routerLink="/news-creator" color="primary" class="text-upper push-top">Create</button>
+    </mat-card-content>
+  </td-layout-card-over>
 </td-layout-nav>

--- a/src/app/news/news.component.ts
+++ b/src/app/news/news.component.ts
@@ -1,8 +1,11 @@
 import { Component } from '@angular/core';
 
+import { appear } from '../animations';
+
 @Component({
   selector: 'app-news',
   templateUrl: './news.component.html',
-  styleUrls: ['./news.component.scss']
+  styleUrls: ['./news.component.scss'],
+  animations: appear
 })
 export class NewsComponent { }

--- a/src/app/news/news.module.ts
+++ b/src/app/news/news.module.ts
@@ -4,6 +4,7 @@ import { CovalentLayoutModule } from '@covalent/core/layout';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCardModule } from '@angular/material/card';
+import { MatDividerModule } from '@angular/material/divider';
 
 import { NewsRoutingModule } from './news-routing.module';
 import { NewsComponent } from './news.component';
@@ -17,6 +18,7 @@ import { NewsArticleComponent } from './news-article/news-article.component';
     MatButtonModule,
     MatIconModule,
     MatCardModule,
+    MatDividerModule,
     ArticlesModule,
     NewsRoutingModule
   ],

--- a/src/app/news/news.module.ts
+++ b/src/app/news/news.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { CovalentLayoutModule } from '@covalent/core/layout';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
 
 import { NewsRoutingModule } from './news-routing.module';
 import { NewsComponent } from './news.component';
@@ -15,6 +16,7 @@ import { NewsArticleComponent } from './news-article/news-article.component';
     CovalentLayoutModule,
     MatButtonModule,
     MatIconModule,
+    MatCardModule,
     ArticlesModule,
     NewsRoutingModule
   ],

--- a/src/constants.scss
+++ b/src/constants.scss
@@ -1,0 +1,7 @@
+// @include mat-core();
+@import '~@angular/material/theming';
+
+$primary: mat-palette($mat-green, 800, 100, 900);
+$accent: mat-palette($mat-light-blue, 600, 100, 900);
+$warn: mat-palette($mat-red, 600, 100, 900);
+$theme: mat-light-theme($primary, $accent, $warn);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,6 +2,7 @@
 
 @import '~@angular/material/theming';
 @import '~@covalent/core/theming/all-theme';
+@import './constants.scss';
 
 // (optional) Additional themes
 @import '~@covalent/markdown/markdown-theme';
@@ -12,13 +13,6 @@
 @include covalent-utilities();
 @include covalent-layout();
 @include covalent-colors();
-
-$primary: mat-palette($mat-green, 800, 100, 900);
-$accent: mat-palette($mat-light-blue, 600, 100, 900);
-
-$warn: mat-palette($mat-red, 600, 100, 900);
-
-$theme: mat-light-theme($primary, $accent, $warn);
 
 @include angular-material-theme($theme);
 @include covalent-theme($theme);

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -42,6 +42,7 @@ export const stocks = {
   stocks: [
     {
       name: 'Dow Jones Industrial Average',
+      image: 'https://upload.wikimedia.org/wikipedia/en/thumb/f/f8/Dow_Jones_Logo.svg/1200px-Dow_Jones_Logo.svg.png',
       symbol: 'DJI',
       value: 25058.12,
       isUp: false,
@@ -84,6 +85,7 @@ export const stocks = {
     },
     {
       name: 'Nasdaq Composite',
+      image: 'https://botw-pd.s3.amazonaws.com/styles/logo-thumbnail/s3/062016/untitled-1_79.png?itok=j9w8nuim',
       symbol: 'IXIC',
       value: 7820.20,
       isUp: false,
@@ -126,6 +128,7 @@ export const stocks = {
     },
     {
       name: 'S&P 500 Index',
+      image: 'https://i.pinimg.com/originals/3c/57/82/3c5782eaf1d40d8fcfd56a96b065392b.jpg',
       symbol: 'INX',
       value: 2801.83,
       isUp: false,


### PR DESCRIPTION
On the dashboard page, added loading animation and animation to all
cards when they appear. Changed the top 3 cards to have an image. Added
more information to the recent news section. Also added the view more
button.

Added animation to news page.

Added animation to news article page and changed the layout to card
over.

In the news creator, added animation to when the page first loads.
Changed the stepper to be vertical and to follow the teradata
recommendations. Added a loading animation when submitting and then a
submit message.

Resolves #16